### PR TITLE
V0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # v0.4.0
 ## Features
-- Added `start_client_arc` which has the same functionality of the `start_client` function but accepts a `Arc<Mutex<Vec<ClientReadyMessage>>>`
+- Added `start_client_arc` which has the same functionality of the `start_client` function but accepts a `Arc<Mutex<Vec<ClientReadyMessage>>>`.
+
+## Fixes
+- Internal changes to client to ensure it continues to receive passed notifications.
 
 # v0.3.3
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.4.0
+## Features
+- Added `start_client_arc` which has the same functionality of the `start_client` function but accepts a `Arc<Mutex<Vec<ClientReadyMessage>>>`
+
 # v0.3.3
 ## Fixes
 - Ensure client shuts down correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Fixes
 - Internal changes to client to ensure it continues to receive passed notifications.
+- Fix cfg statement for pipe interface
 
 # v0.3.3
 ## Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pass-it-on"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Kevin Wheelans <kevin.wheelans@proton.me"]
 edition = "2021"
 rust-version = "1.65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pass-it-on"
 version = "0.4.0"
-authors = ["Kevin Wheelans <kevin.wheelans@proton.me"]
+authors = ["Kevin Wheelans <kevin.wheelans@proton.me>"]
 edition = "2021"
 rust-version = "1.65"
 description = "A library that provides a simple notification client and server that receives messages and passes them on to endpoints"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 
 [features]
 default = ["server-bin","client", "parse-cfg", "pipe", "http", "file", "matrix"]
-client = ["interfaces", "tokio", "tokio/signal", "tokio/time"]
+client = ["interfaces", "tokio", "tokio/signal", "tokio/time", "dep:log"]
 endpoints = ["dep:async-trait","dep:dyn-clone", "dep:typetag"]
 file = ["endpoints", "dep:log", "tokio/io-util"]
 http = ["http-client", "http-server"]
@@ -30,7 +30,7 @@ parse-cfg = ["dep:toml"]
 pipe = ["pipe-client", "pipe-server"]
 pipe-client = ["interfaces", "dep:log", "dep:nix", "tokio/io-util"]
 pipe-server = ["interfaces", "dep:log", "dep:nix","tokio/io-util"]
-server = ["interfaces", "endpoints", "tokio", "tokio/signal", "tokio/time"]
+server = ["interfaces", "endpoints", "tokio", "tokio/signal", "tokio/time", "dep:log"]
 server-bin = ["server", "parse-cfg", "dep:directories", "dep:simple_logger"]
 vendored-tls = ["reqwest/native-tls-vendored"]
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,9 @@
 use crate::configuration::ClientConfiguration;
-use crate::interfaces::setup_client_interfaces;
+use crate::interfaces::{setup_client_interfaces, NANOSECOND, SECOND};
 use crate::notifications::{ClientReadyMessage, Key, Notification};
 use crate::shutdown::listen_for_shutdown;
 use crate::{Error, CHANNEL_BUFFER, LIB_LOG_TARGET};
-use log::{debug, info, warn};
+use log::{debug, error, info, trace, warn};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{broadcast, mpsc, watch};
 
@@ -31,7 +31,6 @@ pub async fn start_client(
     });
 
     // Shutdown
-    info!(target: LIB_LOG_TARGET, "Listening for shutdown signals");
     listen_for_shutdown(shutdown_tx, get_shutdown_wait_time(wait_for_shutdown_secs)).await;
 
     Ok(())
@@ -59,40 +58,9 @@ pub async fn start_client_arc(
     });
 
     // Shutdown
-    info!(target: LIB_LOG_TARGET, "Listening for shutdown signals");
     listen_for_shutdown(shutdown_tx, get_shutdown_wait_time(wait_for_shutdown_secs)).await;
 
     Ok(())
-}
-
-async fn receive_notifications_arc(
-    notifications: Arc<Mutex<Vec<ClientReadyMessage>>>,
-    interface_tx: broadcast::Sender<Notification>,
-    shutdown: watch::Receiver<bool>,
-    key: Key,
-) {
-    info!(target: LIB_LOG_TARGET, "Client waiting for notifications");
-
-    loop {
-        if *shutdown.borrow() {
-            debug!(target: LIB_LOG_TARGET, "receive_notifications_arc received shutdown");
-            break;
-        }
-
-        let messages: Vec<ClientReadyMessage> = notifications.lock().unwrap().drain(0..).collect();
-
-        if !messages.is_empty() {
-            for client_ready_msg in messages {
-                let notification = client_ready_msg.to_notification(&key);
-                debug!(target: LIB_LOG_TARGET, "Client attempting to send Notification: {:?}", notification);
-
-                match interface_tx.send(notification) {
-                    Ok(ok) => debug!(target: LIB_LOG_TARGET, "Message passed to client interfaces: {}", ok),
-                    Err(error) => warn!(target: LIB_LOG_TARGET, "Client broadcast channel send error: {}", error),
-                }
-            }
-        }
-    }
 }
 
 async fn receive_notifications(
@@ -112,15 +80,62 @@ async fn receive_notifications(
                     debug!(target: LIB_LOG_TARGET, "Client Sending Notification: {:?}", notification);
                     match interface_tx.send(notification) {
                         Ok(ok) => debug!(target: LIB_LOG_TARGET, "Message passed to client {} interfaces", ok),
-                        Err(error) => warn!(target: LIB_LOG_TARGET, "Client broadcast channel send error: {}", error),
+                        Err(error) => {
+                            error!(target: LIB_LOG_TARGET, "Client broadcast channel send error: {}", error);
+                            break;
+                        },
                     }
                 }
             }
 
             _ = shutdown_rx.changed() => {
+                trace!(target: LIB_LOG_TARGET, "Shutdown receive_notifications");
                  break;
                 }
+
+            _ = tokio::time::sleep(SECOND) => {
+                trace!(target: LIB_LOG_TARGET, "Sleep timeout reached for receive_notifications");
+            }
         }
+        tokio::time::sleep(NANOSECOND).await;
+    }
+}
+
+async fn receive_notifications_arc(
+    notifications: Arc<Mutex<Vec<ClientReadyMessage>>>,
+    interface_tx: broadcast::Sender<Notification>,
+    shutdown: watch::Receiver<bool>,
+    key: Key,
+) {
+    info!(target: LIB_LOG_TARGET, "Client waiting for notifications");
+
+    let mut shutdown_rx = shutdown.clone();
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.changed() => {
+                trace!(target: LIB_LOG_TARGET, "Shutdown receive_notifications_arc");
+                 break;
+                }
+
+            _ = tokio::time::sleep(SECOND) => {
+                trace!(target: LIB_LOG_TARGET, "Sleep timeout reached for receive_notifications_arc");
+            }
+        }
+
+        let messages: Vec<ClientReadyMessage> = notifications.lock().unwrap().drain(0..).collect();
+
+        if !messages.is_empty() {
+            for client_ready_msg in messages {
+                let notification = client_ready_msg.to_notification(&key);
+                debug!(target: LIB_LOG_TARGET, "Client attempting to send Notification: {:?}", notification);
+
+                match interface_tx.send(notification) {
+                    Ok(ok) => debug!(target: LIB_LOG_TARGET, "Message passed to client interfaces: {}", ok),
+                    Err(error) => warn!(target: LIB_LOG_TARGET, "Client broadcast channel send error: {}", error),
+                }
+            }
+        }
+        tokio::time::sleep(NANOSECOND).await;
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,6 +4,7 @@ use crate::notifications::{ClientReadyMessage, Key, Notification};
 use crate::shutdown::listen_for_shutdown;
 use crate::{Error, LIB_LOG_TARGET};
 use log::{debug, info, warn};
+use std::sync::{Arc, Mutex};
 use tokio::sync::{broadcast, mpsc, watch};
 
 const DEFAULT_WAIT_FOR_SHUTDOWN_SECS: u64 = 2;
@@ -17,12 +18,12 @@ pub async fn start_client(
     wait_for_shutdown_secs: Option<u64>,
 ) -> Result<(), Error> {
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let (interface_tx, _interface_rx) = broadcast::channel(100);
+    let (interface_tx, interface_rx) = broadcast::channel(100);
     let key = client_config.key().clone();
 
     // Setup interfaces to send notifications to
     let interfaces = client_config.interfaces();
-    setup_client_interfaces(interfaces, interface_tx.subscribe(), shutdown_rx.clone()).await?;
+    setup_client_interfaces(interfaces, interface_rx, shutdown_rx.clone()).await?;
 
     // Monitor for incoming notifications
     tokio::spawn(async move {
@@ -30,14 +31,68 @@ pub async fn start_client(
     });
 
     // Shutdown
-    let shutdown_secs = match wait_for_shutdown_secs {
-        None => DEFAULT_WAIT_FOR_SHUTDOWN_SECS,
-        Some(secs) => secs,
-    };
     info!(target: LIB_LOG_TARGET, "Listening for shutdown signals");
-    listen_for_shutdown(shutdown_tx, shutdown_secs).await;
+    listen_for_shutdown(shutdown_tx, get_shutdown_wait_time(wait_for_shutdown_secs)).await;
 
     Ok(())
+}
+
+/// Start the client with provided [`ClientConfiguration`] and `Arc<Mutex<Vec<ClientReadyMessage>>>`.
+///
+/// Client listens for shutdown signals SIGTERM & SIGINT on Unix or CTRL-BREAK and CTRL-C on Windows.
+pub async fn start_client_arc(
+    client_config: ClientConfiguration,
+    notifications: Arc<Mutex<Vec<ClientReadyMessage>>>,
+    wait_for_shutdown_secs: Option<u64>,
+) -> Result<(), Error> {
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (interface_tx, interface_rx) = broadcast::channel(100);
+    let key = client_config.key().clone();
+
+    // Setup interfaces to send notifications to
+    let interfaces = client_config.interfaces();
+    setup_client_interfaces(interfaces, interface_rx, shutdown_rx.clone()).await?;
+
+    // Monitor for incoming notifications
+    tokio::spawn(async move {
+        receive_notifications_arc(notifications, interface_tx, shutdown_rx.clone(), key).await;
+    });
+
+    // Shutdown
+    info!(target: LIB_LOG_TARGET, "Listening for shutdown signals");
+    listen_for_shutdown(shutdown_tx, get_shutdown_wait_time(wait_for_shutdown_secs)).await;
+
+    Ok(())
+}
+
+async fn receive_notifications_arc(
+    notifications: Arc<Mutex<Vec<ClientReadyMessage>>>,
+    interface_tx: broadcast::Sender<Notification>,
+    shutdown: watch::Receiver<bool>,
+    key: Key,
+) {
+    info!(target: LIB_LOG_TARGET, "Client waiting for notifications");
+
+    loop {
+        if *shutdown.borrow() {
+            debug!(target: LIB_LOG_TARGET, "receive_notifications_arc received shutdown");
+            break;
+        }
+
+        let messages: Vec<ClientReadyMessage> = notifications.lock().unwrap().drain(0..).collect();
+
+        if !messages.is_empty() {
+            for client_ready_msg in messages {
+                let notification = client_ready_msg.to_notification(&key);
+                debug!(target: LIB_LOG_TARGET, "Client attempting to send Notification: {:?}", notification);
+
+                match interface_tx.send(notification) {
+                    Ok(ok) => debug!(target: LIB_LOG_TARGET, "Message passed to client interfaces: {}", ok),
+                    Err(error) => warn!(target: LIB_LOG_TARGET, "Client broadcast channel send error: {}", error),
+                }
+            }
+        }
+    }
 }
 
 async fn receive_notifications(
@@ -66,5 +121,12 @@ async fn receive_notifications(
                  break;
                 }
         }
+    }
+}
+
+fn get_shutdown_wait_time(seconds: Option<u64>) -> u64 {
+    match seconds {
+        None => DEFAULT_WAIT_FOR_SHUTDOWN_SECS,
+        Some(secs) => secs,
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@ use crate::configuration::ClientConfiguration;
 use crate::interfaces::setup_client_interfaces;
 use crate::notifications::{ClientReadyMessage, Key, Notification};
 use crate::shutdown::listen_for_shutdown;
-use crate::{Error, LIB_LOG_TARGET};
+use crate::{Error, CHANNEL_BUFFER, LIB_LOG_TARGET};
 use log::{debug, info, warn};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{broadcast, mpsc, watch};
@@ -18,7 +18,7 @@ pub async fn start_client(
     wait_for_shutdown_secs: Option<u64>,
 ) -> Result<(), Error> {
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let (interface_tx, interface_rx) = broadcast::channel(100);
+    let (interface_tx, interface_rx) = broadcast::channel(CHANNEL_BUFFER);
     let key = client_config.key().clone();
 
     // Setup interfaces to send notifications to
@@ -46,7 +46,7 @@ pub async fn start_client_arc(
     wait_for_shutdown_secs: Option<u64>,
 ) -> Result<(), Error> {
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let (interface_tx, interface_rx) = broadcast::channel(100);
+    let (interface_tx, interface_rx) = broadcast::channel(CHANNEL_BUFFER);
     let key = client_config.key().clone();
 
     // Setup interfaces to send notifications to

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -7,7 +7,7 @@ mod server_configuration_file;
 use crate::endpoints::{Endpoint, EndpointChannel};
 use crate::interfaces::Interface;
 use crate::notifications::Key;
-use crate::Error;
+use crate::{Error, CHANNEL_BUFFER};
 
 #[cfg(feature = "server")]
 /// Server configuration that can be used to start the server.
@@ -44,7 +44,7 @@ impl ServerConfiguration {
         let mut endpoints = Vec::new();
         for endpoint in &self.endpoints {
             let (endpoint_tx, _endpoint_rx): (Sender<ValidatedNotification>, Receiver<ValidatedNotification>) =
-                broadcast::channel(100);
+                broadcast::channel(CHANNEL_BUFFER);
             let keys = endpoint.generate_keys(&self.key);
             endpoints.push(EndpointChannel::from(endpoint.clone(), endpoint_tx, keys));
         }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -7,7 +7,7 @@ mod server_configuration_file;
 use crate::endpoints::{Endpoint, EndpointChannel};
 use crate::interfaces::Interface;
 use crate::notifications::Key;
-use crate::{Error, CHANNEL_BUFFER};
+use crate::Error;
 
 #[cfg(feature = "server")]
 /// Server configuration that can be used to start the server.
@@ -38,6 +38,7 @@ impl ServerConfiguration {
 
     pub(crate) fn endpoint_channels(&self) -> Vec<EndpointChannel> {
         use crate::notifications::ValidatedNotification;
+        use crate::CHANNEL_BUFFER;
         use tokio::sync::broadcast;
         use tokio::sync::broadcast::{Receiver, Sender};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,7 +64,7 @@ pub enum Error {
     #[error("Matrix OpenStore Error: {0}")]
     MatrixOpenStoreError(#[from] matrix_sdk::store::OpenStoreError),
 
-    #[cfg(all(unix, feature = "pipe"))]
+    #[cfg(all(unix, any(feature = "pipe-client", feature = "pipe-server", feature = "pipe")))]
     /// Pass-thru `nix::errno::Errno`.
     #[error("Nix ErrorNo Error: {0}")]
     NixErrorNoError(#[from] nix::errno::Errno),

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -5,6 +5,7 @@ use crate::Error;
 use async_trait::async_trait;
 use dyn_clone::DynClone;
 use std::fmt::Debug;
+use std::time::Duration;
 use tokio::sync::{broadcast, mpsc, watch};
 
 #[cfg(all(unix, any(feature = "pipe-client", feature = "pipe-server", feature = "pipe")))]
@@ -12,6 +13,11 @@ pub mod pipe;
 
 #[cfg(any(feature = "http-client", feature = "http-server"))]
 pub mod http;
+
+#[allow(dead_code)]
+pub(crate) const SECOND: Duration = Duration::from_secs(1);
+#[allow(dead_code)]
+pub(crate) const NANOSECOND: Duration = Duration::from_nanos(1);
 
 /// A data structure that can be deserialized and converted into an [`Interface`].
 #[typetag::deserialize(tag = "type")]

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -7,7 +7,7 @@ use dyn_clone::DynClone;
 use std::fmt::Debug;
 use tokio::sync::{broadcast, mpsc, watch};
 
-#[cfg(all(unix, feature = "pipe"))]
+#[cfg(all(unix, any(feature = "pipe-client", feature = "pipe-server", feature = "pipe")))]
 pub mod pipe;
 
 #[cfg(any(feature = "http-client", feature = "http-server"))]

--- a/src/interfaces/http.rs
+++ b/src/interfaces/http.rs
@@ -98,11 +98,11 @@ impl Interface for HttpSocketInterface {
         interface_rx: broadcast::Receiver<Notification>,
         shutdown: watch::Receiver<bool>,
     ) -> Result<(), Error> {
-        use crate::interfaces::http::http_client::start_sending;
+        use crate::interfaces::http::http_client::start_sending_alt;
 
         let url = format!("http://{}:{}/notification", self.ip_or_default(), self.port);
 
-        tokio::spawn(async move { start_sending(interface_rx, shutdown, url.as_str()).await });
+        tokio::spawn(async move { start_sending_alt(interface_rx, shutdown, url.as_str()).await });
         Ok(())
     }
 

--- a/src/interfaces/http.rs
+++ b/src/interfaces/http.rs
@@ -79,7 +79,7 @@ impl Interface for HttpSocketInterface {
 
         let socket = SocketAddr::new(self.ip_or_default(), self.port());
 
-        tokio::spawn(async move { start_monitoring(interface_tx.clone(), shutdown, socket).await });
+        tokio::spawn(async move { start_monitoring(interface_tx, shutdown, socket).await });
         Ok(())
     }
 

--- a/src/interfaces/http/http_client.rs
+++ b/src/interfaces/http/http_client.rs
@@ -1,51 +1,47 @@
+use crate::interfaces::{NANOSECOND, SECOND};
 use crate::notifications::Notification;
 use crate::LIB_LOG_TARGET;
 use log::{debug, error, trace, warn};
 use reqwest::Client;
-use tokio::sync::broadcast::error::TryRecvError;
 use tokio::sync::{broadcast, watch};
 
-pub(super) async fn start_sending(
+pub(super) async fn start_sending_alt(
     interface_rx: broadcast::Receiver<Notification>,
     shutdown: watch::Receiver<bool>,
     url: &str,
 ) {
+    let mut shutdown_rx = shutdown.clone();
     let mut rx = interface_rx.resubscribe();
     let client = Client::new();
 
     loop {
-        if *shutdown.borrow() {
-            trace!(target: LIB_LOG_TARGET, "HTTP Client start_sending received shutdown");
-            break;
-        }
-
-        match rx.try_recv() {
-            Ok(message) => {
-                debug!(target: LIB_LOG_TARGET, "HTTP Client received message");
-                let response = client.post(url).body(message.to_json().unwrap_or_default()).send().await;
-                match response {
-                    Ok(ok) => debug!(
-                        target: LIB_LOG_TARGET,
-                        "HTTP Client Response - status: {} url: {}",
-                        ok.status(),
-                        ok.url()
-                    ),
-                    Err(error) => warn!(target: LIB_LOG_TARGET, "HTTP Client Response Error: {}", error),
+        tokio::select! {
+            received = rx.recv() => {
+                match received {
+                    Ok(message) => {
+                        let response = client.post(url)
+                        .body(message.to_json().unwrap_or_default())
+                        .send().await;
+                        match response {
+                            Ok(ok) => debug!(target: LIB_LOG_TARGET,"HTTP Client Response - status: {} url: {}", ok.status(), ok.url()),
+                            Err(error) => warn!(target: LIB_LOG_TARGET, "HTTP Client Response Error: {}", error ),
+                        }
+                    },
+                    Err(error) => {
+                        error!(target: LIB_LOG_TARGET, "Broadcast Receiver Error: {}", error);
+                        break;
+                    },
                 }
             }
 
-            Err(error) => match error {
-                TryRecvError::Empty => {
-                    trace!(target: LIB_LOG_TARGET, "HTTP Client Broadcast Receiver: {}", error);
-                }
-                TryRecvError::Closed => {
-                    error!(target: LIB_LOG_TARGET, "HTTP Client Broadcast Receiver Error: {}", error);
-                    break;
-                }
-                TryRecvError::Lagged(skipped) => {
-                    warn!(target: LIB_LOG_TARGET, "Broadcast Receiver: {} messages skipped: {}", error, skipped);
-                }
-            },
+            _ = shutdown_rx.changed() => {
+                break;
+            }
+
+            _ = tokio::time::sleep(SECOND) => {
+                trace!(target: LIB_LOG_TARGET, "Sleep timeout reached for http start_sending");
+            }
         }
+        tokio::time::sleep(NANOSECOND).await;
     }
 }

--- a/src/interfaces/http/http_client.rs
+++ b/src/interfaces/http/http_client.rs
@@ -1,7 +1,8 @@
 use crate::notifications::Notification;
 use crate::LIB_LOG_TARGET;
-use log::{debug, error, warn};
+use log::{debug, error, trace, warn};
 use reqwest::Client;
+use tokio::sync::broadcast::error::TryRecvError;
 use tokio::sync::{broadcast, watch};
 
 pub(super) async fn start_sending(
@@ -9,33 +10,42 @@ pub(super) async fn start_sending(
     shutdown: watch::Receiver<bool>,
     url: &str,
 ) {
-    let mut shutdown_rx = shutdown.clone();
     let mut rx = interface_rx.resubscribe();
     let client = Client::new();
 
     loop {
-        tokio::select! {
-            received = rx.recv() => {
-                match received {
-                    Ok(message) => {
-                        let response = client.post(url)
-                        .body(message.to_json().unwrap_or_default())
-                        .send().await;
-                        match response {
-                            Ok(ok) => debug!(target: LIB_LOG_TARGET,"HTTP Client Response - status: {} url: {}", ok.status(), ok.url()),
-                            Err(error) => warn!(target: LIB_LOG_TARGET, "HTTP Client Response Error: {}", error ),
-                        }
-                    },
-                    Err(error) => {
-                        error!(target: LIB_LOG_TARGET, "Broadcast Receiver Error: {}", error);
-                        break;
-                    },
+        if *shutdown.borrow() {
+            trace!(target: LIB_LOG_TARGET, "HTTP Client start_sending received shutdown");
+            break;
+        }
+
+        match rx.try_recv() {
+            Ok(message) => {
+                debug!(target: LIB_LOG_TARGET, "HTTP Client received message");
+                let response = client.post(url).body(message.to_json().unwrap_or_default()).send().await;
+                match response {
+                    Ok(ok) => debug!(
+                        target: LIB_LOG_TARGET,
+                        "HTTP Client Response - status: {} url: {}",
+                        ok.status(),
+                        ok.url()
+                    ),
+                    Err(error) => warn!(target: LIB_LOG_TARGET, "HTTP Client Response Error: {}", error),
                 }
             }
 
-            _ = shutdown_rx.changed() => {
-                break;
-            }
+            Err(error) => match error {
+                TryRecvError::Empty => {
+                    trace!(target: LIB_LOG_TARGET, "HTTP Client Broadcast Receiver: {}", error);
+                }
+                TryRecvError::Closed => {
+                    error!(target: LIB_LOG_TARGET, "HTTP Client Broadcast Receiver Error: {}", error);
+                    break;
+                }
+                TryRecvError::Lagged(skipped) => {
+                    warn!(target: LIB_LOG_TARGET, "Broadcast Receiver: {} messages skipped: {}", error, skipped);
+                }
+            },
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,3 +93,4 @@ pub use self::server::start_server;
 
 /// Logging target value used for the library.
 pub const LIB_LOG_TARGET: &str = "pass_it_on";
+const CHANNEL_BUFFER: usize = 200;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,4 +93,5 @@ pub use self::server::start_server;
 
 /// Logging target value used for the library.
 pub const LIB_LOG_TARGET: &str = "pass_it_on";
+#[allow(dead_code)]
 const CHANNEL_BUFFER: usize = 200;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ mod server;
 pub(crate) mod shutdown;
 
 #[cfg(feature = "client")]
-pub use self::client::start_client;
+pub use self::client::{start_client, start_client_arc};
 #[cfg(feature = "client")]
 pub use self::configuration::ClientConfiguration;
 #[cfg(feature = "server")]

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -15,6 +15,7 @@ pub struct Message {
 }
 
 /// A [`Message`] that has been assigned a notification name
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct ClientReadyMessage {
     message: Message,
     notification_name: String,

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,7 +3,7 @@ use crate::endpoints::{setup_endpoints, EndpointChannel};
 use crate::interfaces::setup_server_interfaces;
 use crate::notifications::{Notification, ValidatedNotification};
 use crate::shutdown::listen_for_shutdown;
-use crate::{Error, LIB_LOG_TARGET};
+use crate::{Error, CHANNEL_BUFFER, LIB_LOG_TARGET};
 use log::{debug, info, warn};
 use tokio::sync::{mpsc, watch};
 
@@ -18,7 +18,7 @@ pub async fn start_server(
 ) -> Result<(), Error> {
     // Setup channels
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let (interface_tx, interface_rx) = mpsc::channel(100);
+    let (interface_tx, interface_rx) = mpsc::channel(CHANNEL_BUFFER);
 
     // Start monitoring the configured interfaces
     let interfaces = server_config.interfaces();

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -7,6 +7,7 @@ use tokio::sync::watch;
 pub(crate) async fn listen_for_shutdown(shutdown_tx: watch::Sender<bool>, seconds_to_wait: u64) {
     use tokio::signal::unix::{signal, SignalKind};
     // Listen for SIGTERM and SIGINT to know when shutdown
+    info!(target: LIB_LOG_TARGET, "Listening for shutdown signals");
     let mut sigterm = signal(SignalKind::terminate()).expect("unable to listen for terminate signal");
     let mut sigint = signal(SignalKind::interrupt()).expect("unable to listen for interrupt signal");
 


### PR DESCRIPTION
## Features
- Added `start_client_arc` which has the same functionality of the `start_client` function but accepts a `Arc<Mutex<Vec<ClientReadyMessage>>>`.

## Fixes
- Internal changes to client to ensure it continues to receive passed notifications.
- Fix cfg statement for pipe interface