### PR TITLE
V0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # v0.6.0
-## Changes
+## Breaking Changes
+### Server Binary
 - Changed default path for pass-it-on-server bin.
 - Changed CLI for pass-it-on-server bin to use clap.
+
+### Library
+- removed `validate` method from `EndpointConfig` trait and changed `to_endpoint` return type to `Result<Box<dyn Endpoint + Send>, Error>`
+- removed `validate` method from `InterfaceConfig` trait and changed `to_interface` return type to `Result<Box<dyn Interface + Send>, Error>`
+- http configuration file now uses `host` and not `ip` to specify the ip address
 
 ## Features
 - added systemd service file under resources.
 - added server configuration example under resources.
+- added error conversion for `Url::ParseError`
+- http configuration file now uses `host` and accepts both IP addresses and URLs.
 
 # v0.5.0
 ## Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.6.0
+## Changes
+- Changed default path for pass-it-on-server bin.
+- Changed CLI for pass-it-on-server bin to use clap.
+
+## Features
+- added systemd service file under resources.
+- added server configuration example under resources.
+
 # v0.5.0
 ## Breaking Changes
 - Deprecated `from_toml` for `ClientConfiguration` and `ServerConfiguration` use `try_from` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added server configuration example under resources.
 - added error conversion for `Url::ParseError`
 - http configuration file now uses `host` and accepts both IP addresses and URLs.
+- Add TLS support for the 
 
 # v0.5.0
 ## Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pass-it-on"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kevin Wheelans <kevin.wheelans@proton.me>"]
 edition = "2021"
 rust-version = "1.65"
@@ -33,12 +33,13 @@ pipe-client = ["interfaces", "dep:log", "dep:nix", "tokio/io-util"]
 pipe-server = ["interfaces", "dep:log", "dep:nix","tokio/io-util"]
 server = ["interfaces", "endpoints", "tokio", "tokio/signal", "tokio/time", "dep:log"]
 server-bin-full = ["server-bin-minimal", "pipe", "http", "file", "matrix", "discord"]
-server-bin-minimal = ["server", "parse-cfg", "dep:directories", "dep:simple_logger"]
+server-bin-minimal = ["server", "parse-cfg", "dep:clap", "dep:directories", "dep:simple_logger"]
 vendored-tls = ["reqwest/native-tls-vendored"]
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
 blake3 = "1"
+clap  = { version = "4.3", features = ["derive", "cargo"], optional = true }
 directories = { version = "5.0", optional = true }
 dyn-clone = { version = "1.0", optional = true }
 log = { version = "0.4", optional = true }
@@ -47,7 +48,7 @@ nix = { version = "0.26", features = ["fs", "net"], default-features = false, op
 reqwest = { version = "0.11", optional = true }
 serde = { version = "1", features = ["default", "derive"] }
 serde_json = "1"
-simple_logger = { version = "4.1", optional = true }
+simple_logger = { version = "4.2", optional = true }
 thiserror = "1"
 tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread"], default-features = false, optional = true }
 toml = { version = "0.7", features = ["parse"], default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread"], defau
 toml = { version = "0.7", features = ["parse"], default-features = false, optional = true }
 typetag = { version = "0.2", optional = true }
 url = { version = "2.4", optional = true }
-warp = { version = "0.3", optional = true }
+warp = { version = "0.3", features = ["tls"], optional = true }
 
 [lib]
 name = "pass_it_on"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ discord = ["endpoints", "dep:log", "reqwest"]
 endpoints = ["dep:async-trait","dep:dyn-clone", "dep:typetag"]
 file = ["endpoints", "dep:log", "tokio/io-util"]
 http = ["http-client", "http-server"]
-http-client = ["interfaces", "reqwest", "dep:log"]
-http-server = ["interfaces", "dep:warp", "dep:log"]
+http-client = ["interfaces", "reqwest", "dep:url", "dep:log"]
+http-server = ["interfaces", "dep:url", "dep:warp", "dep:log"]
 interfaces = ["dep:async-trait","dep:dyn-clone", "dep:typetag"]
 matrix = ["endpoints", "dep:log", "dep:matrix-sdk"]
 parse-cfg = ["dep:toml"]
@@ -53,6 +53,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread"], default-features = false, optional = true }
 toml = { version = "0.7", features = ["parse"], default-features = false, optional = true }
 typetag = { version = "0.2", optional = true }
+url = { version = "2.4", optional = true }
 warp = { version = "0.3", optional = true }
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Interfaces can be used for both the server and the client.
 
 | Interface | Description                                                                          |
 |-----------|--------------------------------------------------------------------------------------|
-| HTTP      | Communication between the client and server using the HTTP protocol.                 |
+| Http      | Communication between the client and server using the Http/Https protocol.           |
 | Pipe      | Communication between the client and server using a FIFO Named Pipe. (**Unix Only**) |
 
 
@@ -61,6 +61,7 @@ group_read_permission = true
 
 [[server.interface]]
 type = "http"
+host = "192.168.1.2"
 port = 8080
 
 [[server.endpoint]]
@@ -107,7 +108,7 @@ group_write_permission = true
 
 [[client.interface]]
 type = "http"
-ip = "192.168.1.2"
+host = "192.168.1.2"
 port = 8080
 ```
 
@@ -120,9 +121,9 @@ port = 8080
 | discord            | Enables the discord webhook endpoint.                                                                                  |
 | endpoints          | Enables the Endpoint and EndpointConfig traits.                                                                        |
 | file               | Enables the regular file endpoint.                                                                                     |
-| http               | Enables the HTTP interface client and server.                                                                          |
-| http-client        | Enables the HTTP interface for just client.                                                                            |
-| http-server        | Enables the HTTP interface for just server.                                                                            |
+| http               | Enables the Http interface client and server.                                                                          |
+| http-client        | Enables the Http interface for just the client.                                                                        |
+| http-server        | Enables the Http interface for just the server.                                                                        |
 | interfaces         | Enables the Interface and InterfaceConfig traits.                                                                      |
 | matrix             | Enables the matrix endpoint.                                                                                           |
 | parse-cfg          | Enables parsing of client or server configurations from TOML when those features are also enabled.                     |
@@ -138,5 +139,4 @@ port = 8080
 ## Future Plans
 - Add Email endpoint
 - Enable encryption support for Matrix endpoint
-- Enable TLS support for the server
 - Make the HTTP interface path configurable instead of the hardcoded `/notification`

--- a/examples/simple_client.rs
+++ b/examples/simple_client.rs
@@ -14,7 +14,7 @@ const CLIENT_TOML_CONFIG: &str = r#"
 
     [[client.interface]]
     type = "http"
-    ip = "127.0.0.1"
+    host = "127.0.0.1"
     port = 8080
 
 "#;

--- a/resources/configuration/server_example.toml
+++ b/resources/configuration/server_example.toml
@@ -9,7 +9,7 @@ key = "replace me"
 
 [[server.interface]]
 type = "http"
-ip = "127.0.0.1"
+host = "http://localhost"
 port = 8080
 
 

--- a/resources/configuration/server_example.toml
+++ b/resources/configuration/server_example.toml
@@ -6,11 +6,37 @@
 [server]
 key = "replace me"
 
-
+###########################################
+# HTTP Socket Interface Localhost Example #
+###########################################
 [[server.interface]]
 type = "http"
-host = "http://localhost"
+host = "localhost"
 port = 8080
+
+
+#####################################
+# HTTP Socket Interface TLS Example #
+#####################################
+# [[server.interface]]
+# type = "http"
+# host = "obsidian.wheelans.net"
+# port = 8081
+# tls = true
+# tls_cert_path = "/path/to/certificate/cert.pem"
+# tls_key_path = "/path/to/private/key/key.pem"
+
+
+###########################
+# Pipe Interface  Example #
+###########################
+# [[server.interface]]
+# type = "pipe"
+# path = '/path/to/pipe.fifo'
+# group_read_permission = true
+# group_write_permission = true
+# other_read_permission = true
+# other_write_permission = false
 
 
 #########################
@@ -26,7 +52,6 @@ port = 8080
 ###########################
 # Matrix Endpoint Example #
 ###########################
-
 # [[server.endpoint]]
 # type = "matrix"
 # home_server = "example.com"
@@ -34,7 +59,6 @@ port = 8080
 # password = "password"
 # session_store_path = '/path/to/session/store/matrix_store'
 # session_store_password = "storepassword"
-
 
 # [[server.endpoint.room]]
 # room = "#matrix-room:example.com"
@@ -44,7 +68,6 @@ port = 8080
 ############################
 # Discord Endpoint Example #
 ############################
-
 # [[server.endpoint]]
 # type = "discord"
 # url = "https://discord.com/api/webhooks/webhook_id/webhook_token"

--- a/resources/configuration/server_example.toml
+++ b/resources/configuration/server_example.toml
@@ -1,0 +1,54 @@
+###################################
+# Pass-it-on Server Configuration #
+###################################
+# Server key must be 32 characters/bytes and must match the clients key
+
+[server]
+key = "replace me"
+
+
+[[server.interface]]
+type = "http"
+ip = "127.0.0.1"
+port = 8080
+
+
+#########################
+# File Endpoint Example #
+#########################
+
+# [[server.endpoint]]
+# type = "file"
+# path = '/test_data/file_endpoint.txt'
+# notifications = ["notification_id1", "notification_id2"]
+
+
+###########################
+# Matrix Endpoint Example #
+###########################
+
+# [[server.endpoint]]
+# type = "matrix"
+# home_server = "example.com"
+# username = "test1"
+# password = "password"
+# session_store_path = '/path/to/session/store/matrix_store'
+# session_store_password = "storepassword"
+
+
+# [[server.endpoint.room]]
+# room = "#matrix-room:example.com"
+# notifications = ["notification_id3"]
+
+
+############################
+# Discord Endpoint Example #
+############################
+
+# [[server.endpoint]]
+# type = "discord"
+# url = "https://discord.com/api/webhooks/webhook_id/webhook_token"
+# notifications = ["notification_id1", "notification_id3"]
+
+# [server.endpoint.allowed_mentions]
+# parse = ["everyone"]

--- a/resources/systemd/pass-it-on-server.service
+++ b/resources/systemd/pass-it-on-server.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Pass-it-on Server
+After=network-online.target
+
+[Service]
+DynamicUser=true
+User=pass-it-on
+ExecPaths=/usr/bin
+
+PrivateUsers=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+NoNewPrivileges=true
+
+ExecStart=/usr/bin/pass-it-on-server --configuration /etc/pass-it-on/server.toml
+
+[Install]
+WantedBy=multi-user.target

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -147,7 +147,7 @@ impl TryFrom<&str> for ClientConfiguration {
     }
 }
 
-#[cfg(all(feature = "parse-cfg", feature = "client"))]
+#[cfg(all(feature = "parse-cfg", any(feature = "client", feature = "server")))]
 fn collect_interfaces(
     interface_configs: Vec<Box<dyn InterfaceConfig>>,
 ) -> Result<Vec<Box<dyn Interface + Send>>, Error> {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -4,8 +4,8 @@ mod client_configuration_file;
 mod server_configuration_file;
 
 #[cfg(feature = "server")]
-use crate::endpoints::{Endpoint, EndpointChannel};
-use crate::interfaces::Interface;
+use crate::endpoints::{Endpoint, EndpointChannel, EndpointConfig};
+use crate::interfaces::{Interface, InterfaceConfig};
 use crate::notifications::Key;
 use crate::Error;
 
@@ -145,4 +145,16 @@ impl TryFrom<&str> for ClientConfiguration {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         client_configuration_file::ClientConfigFileParser::from(value)
     }
+}
+
+#[cfg(all(feature = "parse-cfg", feature = "client"))]
+fn collect_interfaces(
+    interface_configs: Vec<Box<dyn InterfaceConfig>>,
+) -> Result<Vec<Box<dyn Interface + Send>>, Error> {
+    interface_configs.iter().map(|cfg| cfg.to_interface()).collect()
+}
+
+#[cfg(all(feature = "parse-cfg", feature = "server"))]
+fn collect_endpoints(endpoint_configs: Vec<Box<dyn EndpointConfig>>) -> Result<Vec<Box<dyn Endpoint + Send>>, Error> {
+    endpoint_configs.iter().map(|cfg| cfg.to_endpoint()).collect()
 }

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -19,10 +19,7 @@ pub mod matrix;
 #[typetag::deserialize(tag = "type")]
 pub trait EndpointConfig {
     /// Convert this `EndpointConfig` into an [`Endpoint`].
-    fn to_endpoint(&self) -> Box<dyn Endpoint + Send>;
-
-    /// Perform any necessary validations on the configuration to ensure it's usable.
-    fn validate(&self) -> Result<(), Error>;
+    fn to_endpoint(&self) -> Result<Box<dyn Endpoint + Send>, Error>;
 }
 
 /// A data structure that contains information and functions need the server needs to send messages to endpoint.

--- a/src/endpoints/discord.rs
+++ b/src/endpoints/discord.rs
@@ -1,4 +1,22 @@
 //! Discord webhook [`Endpoint`] and [`EndpointConfig`] implementation
+//!
+//!
+//! # Configuration Example
+//! ```toml
+//! [[server.endpoint]]
+//! type = "discord"
+//! url = "https://discord.com/api/webhooks/webhook_id/webhook_token"
+//! username = "Bot Name"
+//! avatar_url = "https://example.com/avatar/url"
+//! tts = true
+//! notifications = ["notification_id1", "notification_id3"]
+//!
+//! [server.endpoint.allowed_mentions]
+//! parse = ["everyone"]
+//! roles = ["role1"]
+//! users = ["user1"]
+//! replied_user = false
+//! ```
 
 pub(crate) mod webhook;
 

--- a/src/endpoints/file.rs
+++ b/src/endpoints/file.rs
@@ -1,4 +1,12 @@
 //! Regular file [`Endpoint`] and [`EndpointConfig`] implementation
+//!
+//! # Configuration Example
+//! ```toml
+//! [[server.endpoint]]
+//! type = "file"
+//! path = 'path/to/file_endpoint.txt'
+//! notifications = ["notification_id1", "notification_id2"]
+//! ```
 
 use crate::endpoints::{Endpoint, EndpointConfig};
 use crate::notifications::{Key, ValidatedNotification};

--- a/src/endpoints/matrix.rs
+++ b/src/endpoints/matrix.rs
@@ -1,4 +1,23 @@
 //! Matrix [`Endpoint`] and [`EndpointConfig`] implementation
+//!
+//! ```toml
+//! [[server.endpoint]]
+//! type = "matrix"
+//! home_server = "example.com"
+//! username = "test1"
+//! password = "password"
+//! session_store_path = '/path/to/session/store/matrix_store'
+//! session_store_password = "storepassword"
+//!
+//!
+//! [[server.endpoint.room]]
+//! room = "#matrix-room:example.com"
+//! notifications = ["notification_id1"]
+//!
+//! [[server.endpoint.room]]
+//! room = "#another-room:example.com"
+//! notifications = ["notification_id2"]
+//! ```
 
 pub(crate) mod notify;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,4 +68,9 @@ pub enum Error {
     /// Pass-thru `nix::errno::Errno`.
     #[error("Nix ErrorNo Error: {0}")]
     NixErrorNoError(#[from] nix::errno::Errno),
+
+    #[cfg(any(feature = "http-client", feature = "http-server"))]
+    /// Pass-thru `url::ParseError`.
+    #[error("Url Parse Error: {0}")]
+    UrlParseError(#[from] url::ParseError),
 }

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -23,10 +23,7 @@ pub(crate) const NANOSECOND: Duration = Duration::from_nanos(1);
 #[typetag::deserialize(tag = "type")]
 pub trait InterfaceConfig {
     /// Convert this `InterfaceConfig` into an [`Interface`].
-    fn to_interface(&self) -> Box<dyn Interface + Send>;
-
-    /// Perform any necessary validations on the configuration to ensure it's usable.
-    fn validate(&self) -> Result<(), Error>;
+    fn to_interface(&self) -> Result<Box<dyn Interface + Send>, Error>;
 }
 
 /// A data structure that contains information and functions needed to communicate on a particular interface between the server and client.

--- a/src/interfaces/http.rs
+++ b/src/interfaces/http.rs
@@ -1,4 +1,20 @@
 //! HTTP [`Interface`] and [`InterfaceConfig`] implementation
+//!
+//! # Server Configuration Example
+//! ```toml
+//! [[server.interface]]
+//! type = "http"
+//! ip = "127.0.0.1"
+//! port = 8080
+//! ```
+//!
+//! # Client Configuration Example
+//! ```toml
+//! [[client.interface]]
+//! type = "http"
+//! ip = "127.0.0.1"
+//! port = 8080
+//! ```
 
 #[cfg(feature = "http-client")]
 pub(crate) mod http_client;

--- a/src/interfaces/http.rs
+++ b/src/interfaces/http.rs
@@ -1,11 +1,23 @@
 //! HTTP [`Interface`] and [`InterfaceConfig`] implementation
 //!
 //! # Server Configuration Example
+//! ## Configuration for Localhost
 //! ```toml
 //! [[server.interface]]
 //! type = "http"
 //! host = "http://localhost"
 //! port = 8080
+//! ```
+//!
+//! ## Configuration with TLS
+//! ```toml
+//! [[server.interface]]
+//! type = "http"
+//! host = "example.com"
+//! port = 8080
+//! tls = true
+//! tls_cert_path = "/path/to/certificate/cert.pem"
+//! tls_key_path = "/path/to/private/key/key.pem"
 //! ```
 //!
 //! # Client Configuration Example

--- a/src/interfaces/http.rs
+++ b/src/interfaces/http.rs
@@ -4,7 +4,7 @@
 //! ```toml
 //! [[server.interface]]
 //! type = "http"
-//! host = "127.0.0.1"
+//! host = "http://localhost"
 //! port = 8080
 //! ```
 //!
@@ -27,6 +27,7 @@ use crate::Error;
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use tokio::sync::{broadcast, mpsc, watch};
 use url::{ParseError, Url};
 
@@ -41,6 +42,8 @@ pub struct HttpSocketInterface {
     host: Url,
     tls: bool,
     port: u16,
+    tls_cert_path: Option<PathBuf>,
+    tls_key_path: Option<PathBuf>,
 }
 
 /// Data structure to represent the HTTP Socket [`InterfaceConfig`].
@@ -50,15 +53,19 @@ pub(crate) struct HttpSocketConfigFile {
     pub host: String,
     pub tls: bool,
     pub port: i64,
+    pub tls_cert_path: Option<String>,
+    pub tls_key_path: Option<String>,
 }
 
 impl HttpSocketInterface {
     /// Create a new `HttpSocketInterface`.
-    pub fn new(host_url: &Url) -> Self {
+    pub fn new<P: AsRef<str>>(host_url: &Url, cert_path: Option<P>, key_path: Option<P>) -> Self {
         let host = host_url.clone();
         let tls = host.scheme().eq_ignore_ascii_case(HTTPS);
         let port = host.port().unwrap_or(DEFAULT_PORT);
-        Self { host, tls, port }
+        let tls_cert_path = cert_path.map(|p| PathBuf::from(p.as_ref()));
+        let tls_key_path = key_path.map(|p| PathBuf::from(p.as_ref()));
+        Self { host, tls, port, tls_cert_path, tls_key_path }
     }
 
     /// Return the IP address.
@@ -75,17 +82,38 @@ impl HttpSocketInterface {
     pub fn port(&self) -> u16 {
         self.port
     }
+
+    /// Return if interface should use TLS
+    pub fn tls(&self) -> bool {
+        self.tls
+    }
+
+    /// Return path the TLS certificate
+    pub fn tls_cert_path(&self) -> &Option<PathBuf> {
+        &self.tls_cert_path
+    }
+
+    /// Return path the TLS private key
+    pub fn tls_key_path(&self) -> &Option<PathBuf> {
+        &self.tls_key_path
+    }
 }
 
 impl Default for HttpSocketConfigFile {
     fn default() -> Self {
-        Self { host: LOCALHOST.into(), tls: false, port: DEFAULT_PORT as i64 }
+        Self { host: LOCALHOST.into(), tls: false, port: DEFAULT_PORT as i64, tls_cert_path: None, tls_key_path: None }
     }
 }
 
 impl Default for HttpSocketInterface {
     fn default() -> Self {
-        Self { host: Url::parse(LOCALHOST).unwrap(), tls: false, port: DEFAULT_PORT }
+        Self {
+            host: Url::parse(LOCALHOST).unwrap(),
+            tls: false,
+            port: DEFAULT_PORT,
+            tls_cert_path: None,
+            tls_key_path: None,
+        }
     }
 }
 
@@ -102,8 +130,9 @@ impl TryFrom<&HttpSocketConfigFile> for HttpSocketInterface {
             false => url.set_scheme(HTTP),
         }
         .unwrap();
+
         url.set_port(Some(value.port as u16)).unwrap();
-        Ok(Self { host: url, tls: value.tls, port: value.port as u16 })
+        Ok(HttpSocketInterface::new(&url, value.tls_cert_path.as_ref(), value.tls_key_path.as_ref()))
     }
 }
 
@@ -120,13 +149,21 @@ impl Interface for HttpSocketInterface {
     async fn receive(&self, interface_tx: mpsc::Sender<String>, shutdown: watch::Receiver<bool>) -> Result<(), Error> {
         use crate::interfaces::http::http_server::start_monitoring;
 
-        for socket in self.sockets()? {
-            let itx = interface_tx.clone();
-            let srx = shutdown.clone();
-            tokio::spawn(async move { start_monitoring(itx, srx, socket).await });
+        if self.tls && (self.tls_cert_path().is_none() || self.tls_cert_path().is_none()) {
+            Err(Error::InvalidInterfaceConfiguration(
+                "Both tls_cert_path and tls_cert_path must be provided for a TLS server".into(),
+            ))
+        } else {
+            for socket in self.sockets()? {
+                let tls = self.tls;
+                let itx = interface_tx.clone();
+                let srx = shutdown.clone();
+                let cert_path = self.tls_cert_path.clone();
+                let key_path = self.tls_key_path.clone();
+                tokio::spawn(async move { start_monitoring(itx, srx, socket, tls, cert_path, key_path).await });
+            }
+            Ok(())
         }
-
-        Ok(())
     }
 
     #[cfg(not(feature = "http-server"))]

--- a/src/interfaces/http/http_client.rs
+++ b/src/interfaces/http/http_client.rs
@@ -5,7 +5,7 @@ use log::{debug, error, trace, warn};
 use reqwest::Client;
 use tokio::sync::{broadcast, watch};
 
-pub(super) async fn start_sending_alt(
+pub(super) async fn start_sending(
     interface_rx: broadcast::Receiver<Notification>,
     shutdown: watch::Receiver<bool>,
     url: &str,

--- a/src/interfaces/http/http_server.rs
+++ b/src/interfaces/http/http_server.rs
@@ -23,7 +23,7 @@ pub(super) async fn start_monitoring<P: AsRef<Path>>(
 
     let filter2 = warp::path!("notification").and(notification_json_body()).and(sender).and_then(receive_notification);
 
-    info!(target: LIB_LOG_TARGET, "Setting up Interface: HttpSocket on -> {}", socket);
+    info!(target: LIB_LOG_TARGET, "Setting up Interface: HttpSocket on -> {} | TLS Enabled -> {}", socket, tls);
     match tls {
         true => {
             let (_address, server) = warp::serve(filter2)
@@ -42,11 +42,6 @@ pub(super) async fn start_monitoring<P: AsRef<Path>>(
             server.await;
         }
     };
-    /*    let (_address, server) = warp::serve(filter2).bind_with_graceful_shutdown(socket, async move {
-        shutdown_rx.changed().await.ok().unwrap_or_default();
-    });*/
-
-    //server.await;
 }
 
 async fn receive_notification(

--- a/src/interfaces/http/http_server.rs
+++ b/src/interfaces/http/http_server.rs
@@ -3,26 +3,50 @@ use crate::LIB_LOG_TARGET;
 use log::{info, warn};
 use std::convert::Infallible;
 use std::net::SocketAddr;
+use std::path::Path;
 use tokio::sync::{mpsc, watch};
 use warp::http::StatusCode;
 use warp::Filter;
 
 const DEFAULT_BODY_LIMIT: u64 = 1024 * 1024;
 
-pub(super) async fn start_monitoring(tx: mpsc::Sender<String>, shutdown: watch::Receiver<bool>, socket: SocketAddr) {
+pub(super) async fn start_monitoring<P: AsRef<Path>>(
+    tx: mpsc::Sender<String>,
+    shutdown: watch::Receiver<bool>,
+    socket: SocketAddr,
+    tls: bool,
+    tls_cert_path: Option<P>,
+    tls_key_path: Option<P>,
+) {
     let mut shutdown_rx = shutdown.clone();
     let sender = warp::any().map(move || tx.clone());
 
     let filter2 = warp::path!("notification").and(notification_json_body()).and(sender).and_then(receive_notification);
 
     info!(target: LIB_LOG_TARGET, "Setting up Interface: HttpSocket on -> {}", socket);
-    //warp::serve(filter2).run(socket).await;
-    //let x = shutdown_rx.changed().await.ok();
-    let (_address, server) = warp::serve(filter2).bind_with_graceful_shutdown(socket, async move {
+    match tls {
+        true => {
+            let (_address, server) = warp::serve(filter2)
+                .tls()
+                .cert_path(tls_cert_path.unwrap().as_ref())
+                .key_path(tls_key_path.unwrap().as_ref())
+                .bind_with_graceful_shutdown(socket, async move {
+                    shutdown_rx.changed().await.ok().unwrap_or_default();
+                });
+            server.await;
+        }
+        false => {
+            let (_address, server) = warp::serve(filter2).bind_with_graceful_shutdown(socket, async move {
+                shutdown_rx.changed().await.ok().unwrap_or_default();
+            });
+            server.await;
+        }
+    };
+    /*    let (_address, server) = warp::serve(filter2).bind_with_graceful_shutdown(socket, async move {
         shutdown_rx.changed().await.ok().unwrap_or_default();
-    });
+    });*/
 
-    server.await;
+    //server.await;
 }
 
 async fn receive_notification(

--- a/src/interfaces/pipe.rs
+++ b/src/interfaces/pipe.rs
@@ -1,4 +1,21 @@
 //! Pipe [`Interface`] and [`InterfaceConfig`]  implementation
+//!
+//! # Server Configuration Example
+//! ```toml
+//! [[server.interface]]
+//! type = "pipe"
+//! path = '/path/to/pipe.fifo'
+//! group_read_permission = true
+//! ```
+//!
+//! # Client Configuration Example
+//! ```toml
+//! [[client.interface]]
+//! type = "pipe"
+//! path = '/path/to/pipe.fifo'
+//! group_read_permission = true
+//! group_write_permission = true
+//! ```
 
 #[cfg(feature = "pipe-client")]
 pub(crate) mod pipe_client;

--- a/src/interfaces/pipe.rs
+++ b/src/interfaces/pipe.rs
@@ -88,24 +88,28 @@ impl PipeInterface {
     }
 }
 
-#[typetag::deserialize(name = "pipe")]
-impl InterfaceConfig for PipeConfigFile {
-    fn to_interface(&self) -> Box<dyn Interface + Send> {
-        Box::new(PipeInterface::new(
-            self.path.as_str(),
-            self.group_read_permission.unwrap_or(false),
-            self.group_write_permission.unwrap_or(false),
-            self.other_read_permission.unwrap_or(false),
-            self.other_write_permission.unwrap_or(false),
-        ))
-    }
+impl TryFrom<&PipeConfigFile> for PipeInterface {
+    type Error = Error;
 
-    fn validate(&self) -> Result<(), Error> {
-        if self.path.is_empty() {
+    fn try_from(value: &PipeConfigFile) -> Result<Self, Self::Error> {
+        if value.path.is_empty() {
             return Err(Error::InvalidInterfaceConfiguration("Pipe path is empty".to_string()));
         }
 
-        Ok(())
+        Ok(Self {
+            path: PathBuf::from(value.path.as_str()),
+            group_read: value.group_read_permission.unwrap_or(false),
+            group_write: value.group_write_permission.unwrap_or(false),
+            other_read: value.other_read_permission.unwrap_or(false),
+            other_write: value.other_write_permission.unwrap_or(false),
+        })
+    }
+}
+
+#[typetag::deserialize(name = "pipe")]
+impl InterfaceConfig for PipeConfigFile {
+    fn to_interface(&self) -> Result<Box<dyn Interface + Send>, Error> {
+        Ok(Box::new(PipeInterface::try_from(self)?))
     }
 }
 

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -7,7 +7,6 @@ use tokio::sync::watch;
 pub(crate) async fn listen_for_shutdown(shutdown_tx: watch::Sender<bool>, seconds_to_wait: u64) {
     use tokio::signal::unix::{signal, SignalKind};
     // Listen for SIGTERM and SIGINT to know when shutdown
-    info!(target: LIB_LOG_TARGET, "Listening for shutdown signals");
     let mut sigterm = signal(SignalKind::terminate()).expect("unable to listen for terminate signal");
     let mut sigint = signal(SignalKind::interrupt()).expect("unable to listen for interrupt signal");
 


### PR DESCRIPTION
# v0.6.0
## Breaking Changes
### Server Binary
- Changed default path for pass-it-on-server bin.
- Changed CLI for pass-it-on-server bin to use clap.

### Library
- removed `validate` method from `EndpointConfig` trait and changed `to_endpoint` return type to `Result<Box<dyn Endpoint + Send>, Error>`
- removed `validate` method from `InterfaceConfig` trait and changed `to_interface` return type to `Result<Box<dyn Interface + Send>, Error>`
- http configuration file now uses `host` and not `ip` to specify the ip address

## Features
- added systemd service file under resources.
- added server configuration example under resources.
- added error conversion for `Url::ParseError`
- http configuration file now uses `host` and accepts both IP addresses and URLs.
- Add TLS support for the 