### PR TITLE
Feature/enhance client server shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,19 +39,19 @@ vendored-tls = ["reqwest/native-tls-vendored"]
 [dependencies]
 async-trait = { version = "0.1", optional = true }
 blake3 = "1"
-clap  = { version = "4.3", features = ["derive", "cargo"], optional = true }
+clap  = { version = "4.4", features = ["derive", "cargo"], optional = true }
 directories = { version = "5.0", optional = true }
 dyn-clone = { version = "1.0", optional = true }
 log = { version = "0.4", optional = true }
 matrix-sdk = { version = "0.6", optional = true }
-nix = { version = "0.26", features = ["fs", "net"], default-features = false, optional = true }
+nix = { version = "0.27", features = ["fs", "net"], default-features = false, optional = true }
 reqwest = { version = "0.11", optional = true }
 serde = { version = "1", features = ["default", "derive"] }
 serde_json = "1"
 simple_logger = { version = "4.2", optional = true }
 thiserror = "1"
 tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread"], default-features = false, optional = true }
-toml = { version = "0.7", features = ["parse"], default-features = false, optional = true }
+toml = { version = "0.8", features = ["parse"], default-features = false, optional = true }
 typetag = { version = "0.2", optional = true }
 url = { version = "2.4", optional = true }
 warp = { version = "0.3", features = ["tls"], optional = true }

--- a/src/bin/pass-it-on-server.rs
+++ b/src/bin/pass-it-on-server.rs
@@ -50,5 +50,5 @@ async fn run(args: CliArgs) -> Result<(), Error> {
         ServerConfiguration::try_from(std::fs::read_to_string(config_path)?.as_str())?
     };
 
-    start_server(server_config, None).await
+    start_server(server_config, None, None).await
 }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -4,16 +4,29 @@ use std::time::Duration;
 use tokio::sync::watch;
 
 #[cfg(unix)]
-pub(crate) async fn listen_for_shutdown(shutdown_tx: watch::Sender<bool>, seconds_to_wait: u64) {
+pub(crate) async fn listen_for_shutdown(
+    shutdown_tx: watch::Sender<bool>,
+    shutdown: Option<watch::Receiver<bool>>,
+    seconds_to_wait: u64,
+) {
     use tokio::signal::unix::{signal, SignalKind};
     // Listen for SIGTERM and SIGINT to know when shutdown
     let mut sigterm = signal(SignalKind::terminate()).expect("unable to listen for terminate signal");
     let mut sigint = signal(SignalKind::interrupt()).expect("unable to listen for interrupt signal");
 
-    tokio::select! {
+    if let Some(mut shutdown_rx) = shutdown {
+        tokio::select! {
         _ = sigterm.recv() => info!(target: LIB_LOG_TARGET, "Received SIGTERM."),
         _ = sigint.recv() => info!(target: LIB_LOG_TARGET, "Received SIGINT."),
+        _ = shutdown_rx.changed() => info!(target: LIB_LOG_TARGET, "Received shutdown channel signal."),
+        }
+    } else {
+        tokio::select! {
+        _ = sigterm.recv() => info!(target: LIB_LOG_TARGET, "Received SIGTERM."),
+        _ = sigint.recv() => info!(target: LIB_LOG_TARGET, "Received SIGINT."),
+        }
     }
+
     // Send shutdown signal
     if let Err(error) = shutdown_tx.send(true) {
         error!(target: LIB_LOG_TARGET, "Unable to send shutdown signal: {}", error)
@@ -32,10 +45,19 @@ pub(crate) async fn listen_for_shutdown(shutdown_tx: watch::Sender<bool>, second
     let mut sig_ctrl_break = ctrl_break().expect("unable to listen for ctrl-break signal");
     let mut sig_ctrl_c = ctrl_c().expect("unable to listen for ctrl-c signal");
 
-    tokio::select! {
+    if let Some(mut shutdown_rx) = shutdown {
+        tokio::select! {
         _ = sig_ctrl_break.recv() => info!(target: LIB_LOG_TARGET, "Received CTRL-BREAK."),
         _ = sig_ctrl_c.recv() => info!(target: LIB_LOG_TARGET, "Received CTRL-C."),
+        _ = shutdown_rx.changed() => info!(target: LIB_LOG_TARGET, "Received shutdown channel signal."),
+        }
+    } else {
+        tokio::select! {
+            _ = sig_ctrl_break.recv() => info!(target: LIB_LOG_TARGET, "Received CTRL-BREAK."),
+            _ = sig_ctrl_c.recv() => info!(target: LIB_LOG_TARGET, "Received CTRL-C."),
+        }
     }
+
     // Send shutdown signal
     if let Err(error) = shutdown_tx.send(true) {
         error!(target: LIB_LOG_TARGET, "Unable to send shutdown signal: {}", error)


### PR DESCRIPTION
Breaking Change
modify shutdown for server and client to optionally accept shutdown from a watch channel in addition to the existing signals