### PR TITLE
Add Matrix backup & recover with passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Unreleased
+## Features
+- Added functionality to create and recover Matrix homeserver backups with a passphrase for `MatrixEndpoint`.
+If no backup exists on the homeserver one will be created with the provided passphrase.
+If a backup does exist on the homeserver then recovery will be attempted with the provided passphrase.
+- Automatically enable cross signing
+
+## Changes
+- Changed session_store_password to recovery_passphrase for `MatrixEndpoint`
+- Automatically enable cross signing when building `Client` for `MatrixEndpoint`
+- 
 
 # v0.14.4
 ## Changes

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ home_server = "example.com"
 username = "test1"
 password = "pass"
 session_store_path = '/path/to/session/store/matrix_store'
-session_store_password = "storepass123"
+recovery_passphrase = "recover123"
 
 [[server.endpoint.room]]
 room = "!dfsdfsdf:example.com"

--- a/resources/configuration/server_example.toml
+++ b/resources/configuration/server_example.toml
@@ -58,7 +58,7 @@ port = 8080
 # username = "test1"
 # password = "password"
 # session_store_path = '/path/to/session/store/matrix_store'
-# session_store_password = "storepassword"
+# recovery_passphrase = "storepassword"
 
 # [[server.endpoint.room]]
 # room = "#matrix-room:example.com"

--- a/src/endpoints/matrix/verify.rs
+++ b/src/endpoints/matrix/verify.rs
@@ -39,7 +39,7 @@ pub(crate) async fn verify_devices(endpoints: &[Box<dyn Endpoint + Send>]) -> Re
 }
 
 async fn verify_device(endpoint: &MatrixEndpoint) -> Result<(), Error> {
-    let (client, _session) = login(ClientInfo::try_from(endpoint)?).await?;
+    let client = login(ClientInfo::try_from(endpoint)?).await?;
 
     client.add_event_handler(|event: ToDeviceKeyVerificationRequestEvent, client: Client| async move {
         let request = client

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,11 @@ pub enum Error {
     #[error("Matrix SecretStorage Error: {0}")]
     MatrixSecretStoreError(#[from] matrix_sdk::encryption::secret_storage::SecretStorageError),
 
+    #[cfg(feature = "matrix")]
+    /// Pass-thru `matrix_sdk::encryption::recovery::RecoveryError`.
+    #[error("Matrix RecoveryError Error: {0}")]
+    MatrixRecoveryError(#[from] matrix_sdk::encryption::recovery::RecoveryError),
+
     #[cfg(all(unix, any(feature = "pipe-client", feature = "pipe-server", feature = "pipe")))]
     /// Pass-thru `nix::errno::Errno`.
     #[error("Nix ErrorNo Error: {0}")]

--- a/tests/server_configuration_tests.rs
+++ b/tests/server_configuration_tests.rs
@@ -82,7 +82,7 @@ fn server_valid_config_matrix() {
     username = "test1"
     password = "pass"
     session_store_path = '/test_data/matrix_store'
-    session_store_password = "storepass123"
+    recovery_passphrase = "storepass123"
 
     [[server.endpoint.room]]
     room = "!dfsdfsdf:example.com"


### PR DESCRIPTION
## Features
- Added functionality to create and recover Matrix homeserver backups with a passphrase for `MatrixEndpoint`.
If no backup exists on the homeserver one will be created with the provided passphrase.
If a backup does exist on the homeserver then recovery will be attempted with the provided passphrase.
- Automatically enable cross signing

## Changes
- Changed session_store_password to recovery_passphrase for `MatrixEndpoint`
- Automatically enable cross signing when building `Client` for `MatrixEndpoint`
- 